### PR TITLE
Correct resources_rc path reference.

### DIFF
--- a/mapclientplugins/scaffoldcreator/view/ui_scaffoldcreatorwidget.py
+++ b/mapclientplugins/scaffoldcreator/view/ui_scaffoldcreatorwidget.py
@@ -23,7 +23,7 @@ from PySide6.QtWidgets import (QApplication, QCheckBox, QComboBox, QDockWidget,
 
 from mapclientplugins.scaffoldcreator.view.nodeeditorsceneviewerwidget import NodeEditorSceneviewerWidget
 from opencmiss.zincwidgets.fieldchooserwidget import FieldChooserWidget
-from  . import resources_rc
+from mapclientplugins.scaffoldcreator import resources_rc
 
 class Ui_ScaffoldCreatorWidget(object):
     def setupUi(self, ScaffoldCreatorWidget):


### PR DESCRIPTION
When compiling the Qt resources for the PySide6 upgrade the compiler inserted an incorrect path to the resources_rc file.