### PR TITLE
Fix highlighting and redefinition of annotation group

### DIFF
--- a/mapclientplugins/scaffoldcreator/model/scaffoldcreatormodel.py
+++ b/mapclientplugins/scaffoldcreator/model/scaffoldcreatormodel.py
@@ -310,11 +310,10 @@ class ScaffoldCreatorModel(object):
         # can only redefine user annotation groups which are not markers
         assert self.isUserAnnotationGroup(self._currentAnnotationGroup)
         assert not self._currentAnnotationGroup.isMarker()
-        fieldmodule = self._region.getFieldmodule()
-        with ChangeManager(fieldmodule):
+        parentScene = self._parentRegion.getScene()
+        scene = self._region.getScene()
+        with ChangeManager(parentScene), ChangeManager(scene), HierarchicalChangeManager(self._parentRegion):
             self._currentAnnotationGroup.clear()
-            parentScene = self._parentRegion.getScene()
-            scene = self._region.getScene()
             selectionGroup = get_scene_selection_group(parentScene)
             if selectionGroup:
                 subregionGroup = selectionGroup.getSubregionFieldGroup(self._region)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ requires = [
     "scaffoldmaker >= 0.8",
     "opencmiss.maths",
     "opencmiss.utils >= 0.3",
-    "opencmiss.zinc >= 3.9",
+    "opencmiss.zinc >= 3.10.2",
     "opencmiss.zincwidgets >= 2.0",
     "PySide2"
 ]


### PR DESCRIPTION
Follow practice of using selection group in root scene only and use standard name of selection group from opencmiss.zincwidgets.