### PR TITLE
Add GroupManagerWidget to Edit button

### DIFF
--- a/mapclientplugins/scaffoldcreator/qt/scaffoldcreatorwidget.ui
+++ b/mapclientplugins/scaffoldcreator/qt/scaffoldcreatorwidget.ui
@@ -113,8 +113,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>446</width>
-            <height>726</height>
+            <width>521</width>
+            <height>716</height>
            </rect>
           </property>
           <property name="sizePolicy">
@@ -124,7 +124,16 @@
            </sizepolicy>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_2">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -171,7 +180,16 @@
                    <enum>QFrame::Raised</enum>
                   </property>
                   <layout class="QVBoxLayout" name="verticalLayout_5">
-                   <property name="margin">
+                   <property name="leftMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="topMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="rightMargin">
+                    <number>0</number>
+                   </property>
+                   <property name="bottomMargin">
                     <number>0</number>
                    </property>
                    <item>
@@ -284,7 +302,16 @@
                       <enum>QFrame::Raised</enum>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_10">
-                      <property name="margin">
+                      <property name="leftMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="rightMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="bottomMargin">
                        <number>0</number>
                       </property>
                       <item>
@@ -394,7 +421,16 @@
               <enum>QFrame::Raised</enum>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_11">
-              <property name="margin">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
                <number>0</number>
               </property>
               <item>
@@ -406,7 +442,16 @@
                  <enum>QFrame::Raised</enum>
                 </property>
                 <layout class="QHBoxLayout" name="horizontalLayout_9">
-                 <property name="margin">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
                   <number>0</number>
                  </property>
                  <item>
@@ -455,7 +500,16 @@
                  <enum>QFrame::Raised</enum>
                 </property>
                 <layout class="QHBoxLayout" name="horizontalLayout_10">
-                 <property name="margin">
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
                   <number>0</number>
                  </property>
                  <item>
@@ -503,7 +557,16 @@
               <property name="fieldGrowthPolicy">
                <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
               </property>
-              <property name="margin">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
                <number>0</number>
               </property>
               <item row="0" column="0">
@@ -528,7 +591,16 @@
               <enum>QFrame::Raised</enum>
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_6">
-              <property name="margin">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
                <number>0</number>
               </property>
               <item>
@@ -592,7 +664,16 @@
               <enum>QFrame::Raised</enum>
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_7">
-              <property name="margin">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
                <number>0</number>
               </property>
               <item>
@@ -711,7 +792,16 @@
               <enum>QFrame::Raised</enum>
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_5">
-              <property name="margin">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
                <number>0</number>
               </property>
               <item>
@@ -766,7 +856,16 @@
               <enum>QFrame::Raised</enum>
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_3">
-              <property name="margin">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
                <number>0</number>
               </property>
               <item>
@@ -840,7 +939,16 @@
               <enum>QFrame::Raised</enum>
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_4">
-              <property name="margin">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
                <number>0</number>
               </property>
               <item>
@@ -888,7 +996,16 @@
               <enum>QFrame::Raised</enum>
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_8">
-              <property name="margin">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
                <number>0</number>
               </property>
               <item>
@@ -937,7 +1054,16 @@
               <enum>QFrame::Raised</enum>
              </property>
              <layout class="QHBoxLayout" name="horizontalLayout_11">
-              <property name="margin">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
                <number>0</number>
               </property>
               <item>
@@ -962,6 +1088,13 @@
                </widget>
               </item>
               <item>
+               <widget class="QPushButton" name="annotationGroupEdit_pushButton">
+                <property name="text">
+                 <string>Edit</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QPushButton" name="annotationGroupDelete_pushButton">
                 <property name="text">
                  <string>Delete</string>
@@ -980,7 +1113,16 @@
               <enum>QFrame::Raised</enum>
              </property>
              <layout class="QFormLayout" name="formLayout_2">
-              <property name="margin">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
                <number>0</number>
               </property>
               <item row="1" column="0">
@@ -1056,7 +1198,16 @@
                     <enum>QFrame::Raised</enum>
                    </property>
                    <layout class="QFormLayout" name="formLayout_4">
-                    <property name="margin">
+                    <property name="leftMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="topMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="rightMargin">
+                     <number>0</number>
+                    </property>
+                    <property name="bottomMargin">
                      <number>0</number>
                     </property>
                     <item row="3" column="0">
@@ -1121,16 +1272,25 @@
           <enum>QFrame::Raised</enum>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <property name="margin">
+          <property name="leftMargin">
            <number>3</number>
           </property>
-            <item>
-                <widget class="QPushButton" name="pushButtonDocumentation">
-                    <property name="text">
-                    <string>Online Documentation</string>
-                    </property>
-                </widget>
-            </item>
+          <property name="topMargin">
+           <number>3</number>
+          </property>
+          <property name="rightMargin">
+           <number>3</number>
+          </property>
+          <property name="bottomMargin">
+           <number>3</number>
+          </property>
+          <item>
+           <widget class="QPushButton" name="pushButtonDocumentation">
+            <property name="text">
+             <string>Online Documentation</string>
+            </property>
+           </widget>
+          </item>
           <item>
            <widget class="QPushButton" name="viewAll_pushButton">
             <property name="text">

--- a/mapclientplugins/scaffoldcreator/view/scaffoldcreatorwidget.py
+++ b/mapclientplugins/scaffoldcreator/view/scaffoldcreatorwidget.py
@@ -303,8 +303,8 @@ class ScaffoldCreatorWidget(QtWidgets.QWidget):
             reply = QtWidgets.QMessageBox.question(
                 self, 'Confirm action',
                 'Redefine annotation group \'' + annotationGroup.getName() + '\' from selection?',
-                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No, QtWidgets.QMessageBox.No)
-            if reply == QtWidgets.QMessageBox.Yes:
+                QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No, QtWidgets.QMessageBox.StandardButton.No)
+            if reply == QtWidgets.QMessageBox.StandardButton.Yes:
                 if self._scaffold_model.redefineCurrentAnnotationGroupFromSelection():
                     self._refreshCurrentAnnotationGroupSettings()
 
@@ -314,12 +314,15 @@ class ScaffoldCreatorWidget(QtWidgets.QWidget):
         currentAnnotationGroup = self._scaffold_model.getCurrentAnnotationGroup()
         current_zinc_group = currentAnnotationGroup.getGroup()
 
+        # Call a refresh to make the current selection view consistent with the current group.
+        self._refresh()
         group_editor = GroupEditorWidget(self, current_zinc_group, zinc_groups)
         group_editor.group_updated.connect(self._refresh)
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(group_editor)
         dlg = QtWidgets.QDialog(self)
-        dlg.setWindowFlags(dlg.windowFlags() | QtCore.Qt.WindowContextHelpButtonHint)
+        group_editor.close_requested.connect(dlg.close)
+        dlg.setWindowFlags(dlg.windowFlags() | QtCore.Qt.WindowType.WindowContextHelpButtonHint)
         dlg.setLayout(layout)
         dlg.resize(600, 400)
         dlg.show()
@@ -333,8 +336,8 @@ class ScaffoldCreatorWidget(QtWidgets.QWidget):
             reply = QtWidgets.QMessageBox.question(
                 self, 'Confirm action',
                 'Delete annotation group \'' + annotationGroup.getName() + '\'?',
-                QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No, QtWidgets.QMessageBox.No)
-            if reply == QtWidgets.QMessageBox.Yes:
+                QtWidgets.QMessageBox.StandardButton.Yes | QtWidgets.QMessageBox.StandardButton.No, QtWidgets.QMessageBox.StandardButton.No)
+            if reply == QtWidgets.QMessageBox.StandardButton.Yes:
                 if self._scaffold_model.deleteAnnotationGroup(annotationGroup):
                     self._refreshAnnotationGroups()
                     self._refreshCurrentAnnotationGroupSettings()

--- a/mapclientplugins/scaffoldcreator/view/scaffoldcreatorwidget.py
+++ b/mapclientplugins/scaffoldcreator/view/scaffoldcreatorwidget.py
@@ -9,7 +9,7 @@ from functools import partial
 from mapclientplugins.scaffoldcreator.view.ui_scaffoldcreatorwidget import Ui_ScaffoldCreatorWidget
 from mapclientplugins.scaffoldcreator.view.functionoptionsdialog import FunctionOptionsDialog
 from cmlibs.maths.vectorops import dot, magnitude, mult, normalize, sub
-from cmlibs.widgets.groupmanagerwidget import GroupManagerWidget
+from cmlibs.widgets.groupeditorwidget import GroupEditorWidget
 from cmlibs.utils.zinc.field import fieldIsManagedCoordinates
 from scaffoldmaker.scaffoldpackage import ScaffoldPackage
 
@@ -314,10 +314,10 @@ class ScaffoldCreatorWidget(QtWidgets.QWidget):
         currentAnnotationGroup = self._scaffold_model.getCurrentAnnotationGroup()
         current_zinc_group = currentAnnotationGroup.getGroup()
 
-        group_manager = GroupManagerWidget(current_zinc_group, zinc_groups)
-        group_manager.group_updated.connect(self._refresh)
+        group_editor = GroupEditorWidget(self, current_zinc_group, zinc_groups)
+        group_editor.group_updated.connect(self._refresh)
         layout = QtWidgets.QVBoxLayout()
-        layout.addWidget(group_manager)
+        layout.addWidget(group_editor)
         dlg = QtWidgets.QDialog(self)
         dlg.setWindowFlags(dlg.windowFlags() | QtCore.Qt.WindowContextHelpButtonHint)
         dlg.setLayout(layout)

--- a/mapclientplugins/scaffoldcreator/view/scaffoldcreatorwidget.py
+++ b/mapclientplugins/scaffoldcreator/view/scaffoldcreatorwidget.py
@@ -9,6 +9,7 @@ from functools import partial
 from mapclientplugins.scaffoldcreator.view.ui_scaffoldcreatorwidget import Ui_ScaffoldCreatorWidget
 from mapclientplugins.scaffoldcreator.view.functionoptionsdialog import FunctionOptionsDialog
 from cmlibs.maths.vectorops import dot, magnitude, mult, normalize, sub
+from cmlibs.widgets.groupmanagerwidget import GroupManagerWidget
 from cmlibs.utils.zinc.field import fieldIsManagedCoordinates
 from scaffoldmaker.scaffoldpackage import ScaffoldPackage
 
@@ -37,6 +38,17 @@ def QLineEdit_parseVector(lineedit):
     except ValueError:
         pass
     return None
+
+
+def get_zinc_groups(annotation_groups):
+    """
+    Convert a list of AnnotationGroups into a list of Zinc FieldGroups.
+    """
+    zinc_groups = []
+    for annotation_group in annotation_groups:
+        zinc_group = annotation_group.getGroup()
+        zinc_groups.append(zinc_group)
+    return zinc_groups
 
 
 class ScaffoldCreatorWidget(QtWidgets.QWidget):
@@ -159,6 +171,7 @@ class ScaffoldCreatorWidget(QtWidgets.QWidget):
         self._ui.annotationGroupNew_pushButton.clicked.connect(self._annotationGroupNewButtonClicked)
         self._ui.annotationGroupNewMarker_pushButton.clicked.connect(self._annotationGroupNewMarkerButtonClicked)
         self._ui.annotationGroupRedefine_pushButton.clicked.connect(self._annotationGroupRedefineButtonClicked)
+        self._ui.annotationGroupEdit_pushButton.clicked.connect(self._annotationGroupEditButtonClicked)
         self._ui.annotationGroupDelete_pushButton.clicked.connect(self._annotationGroupDeleteButtonClicked)
         self._ui.annotationGroupOntId_lineEdit.editingFinished.connect(self._annotationGroupOntIdLineEditChanged)
         self._ui.markerMaterialCoordinatesField_fieldChooser.setRegion(self._scaffold_model.getRegion())
@@ -295,6 +308,25 @@ class ScaffoldCreatorWidget(QtWidgets.QWidget):
                 if self._scaffold_model.redefineCurrentAnnotationGroupFromSelection():
                     self._refreshCurrentAnnotationGroupSettings()
 
+    def _annotationGroupEditButtonClicked(self):
+        annotationGroups = self._scaffold_model.getAnnotationGroups()
+        zinc_groups = get_zinc_groups(annotationGroups)
+        currentAnnotationGroup = self._scaffold_model.getCurrentAnnotationGroup()
+        current_zinc_group = currentAnnotationGroup.getGroup()
+
+        group_manager = GroupManagerWidget(current_zinc_group, zinc_groups)
+        group_manager.group_updated.connect(self._refresh)
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(group_manager)
+        dlg = QtWidgets.QDialog(self)
+        dlg.setWindowFlags(dlg.windowFlags() | QtCore.Qt.WindowContextHelpButtonHint)
+        dlg.setLayout(layout)
+        dlg.resize(600, 400)
+        dlg.show()
+
+    def _refresh(self):
+        self._annotationGroupChanged(self._ui.annotationGroup_comboBox.currentIndex())
+
     def _annotationGroupDeleteButtonClicked(self):
         annotationGroup = self._scaffold_model.getCurrentAnnotationGroup()
         if annotationGroup:
@@ -398,6 +430,7 @@ class ScaffoldCreatorWidget(QtWidgets.QWidget):
         self._ui.annotationGroupDimension_spinBox.setValue(annotationGroup.getDimension() if annotationGroup else 0)
         self._ui.annotationGroupDimension_spinBox.setEnabled(False)
         self._ui.annotationGroupRedefine_pushButton.setEnabled(isUser and not annotationGroup.isMarker())
+        self._ui.annotationGroupEdit_pushButton.setEnabled(isUser and not annotationGroup.isMarker())
         self._ui.annotationGroupDelete_pushButton.setEnabled(isUser)
         markerMaterialCoordinatesField = None
         markerMaterialCoordinatesText = ""

--- a/mapclientplugins/scaffoldcreator/view/ui_scaffoldcreatorwidget.py
+++ b/mapclientplugins/scaffoldcreator/view/ui_scaffoldcreatorwidget.py
@@ -3,7 +3,7 @@
 ################################################################################
 ## Form generated from reading UI file 'scaffoldcreatorwidget.ui'
 ##
-## Created by: Qt User Interface Compiler version 6.4.1
+## Created by: Qt User Interface Compiler version 6.5.1
 ##
 ## WARNING! All changes made in this file will be lost when recompiling UI file!
 ################################################################################
@@ -78,12 +78,12 @@ class Ui_ScaffoldCreatorWidget(object):
         self.scrollArea.setWidgetResizable(True)
         self.scrollAreaWidgetContents_2 = QWidget()
         self.scrollAreaWidgetContents_2.setObjectName(u"scrollAreaWidgetContents_2")
-        self.scrollAreaWidgetContents_2.setGeometry(QRect(0, 0, 446, 726))
+        self.scrollAreaWidgetContents_2.setGeometry(QRect(0, 0, 521, 716))
         sizePolicy1.setHeightForWidth(self.scrollAreaWidgetContents_2.sizePolicy().hasHeightForWidth())
         self.scrollAreaWidgetContents_2.setSizePolicy(sizePolicy1)
         self.verticalLayout_2 = QVBoxLayout(self.scrollAreaWidgetContents_2)
-        self.verticalLayout_2.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_2.setObjectName(u"verticalLayout_2")
+        self.verticalLayout_2.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_3 = QVBoxLayout()
         self.verticalLayout_3.setObjectName(u"verticalLayout_3")
         self.scaffoldFrame = QFrame(self.scrollAreaWidgetContents_2)
@@ -103,8 +103,8 @@ class Ui_ScaffoldCreatorWidget(object):
         self.subscaffold_frame.setFrameShape(QFrame.StyledPanel)
         self.subscaffold_frame.setFrameShadow(QFrame.Raised)
         self.verticalLayout_5 = QVBoxLayout(self.subscaffold_frame)
-        self.verticalLayout_5.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_5.setObjectName(u"verticalLayout_5")
+        self.verticalLayout_5.setContentsMargins(0, 0, 0, 0)
         self.subscaffold_label = QLabel(self.subscaffold_frame)
         self.subscaffold_label.setObjectName(u"subscaffold_label")
 
@@ -182,8 +182,8 @@ class Ui_ScaffoldCreatorWidget(object):
         self.deleteElementsRanges_frame.setFrameShape(QFrame.StyledPanel)
         self.deleteElementsRanges_frame.setFrameShadow(QFrame.Raised)
         self.verticalLayout_10 = QVBoxLayout(self.deleteElementsRanges_frame)
-        self.verticalLayout_10.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_10.setObjectName(u"verticalLayout_10")
+        self.verticalLayout_10.setContentsMargins(0, 0, 0, 0)
         self.deleteElementsRanges_label = QLabel(self.deleteElementsRanges_frame)
         self.deleteElementsRanges_label.setObjectName(u"deleteElementsRanges_label")
 
@@ -270,15 +270,15 @@ class Ui_ScaffoldCreatorWidget(object):
         self.displayData_frame.setFrameShape(QFrame.StyledPanel)
         self.displayData_frame.setFrameShadow(QFrame.Raised)
         self.verticalLayout_11 = QVBoxLayout(self.displayData_frame)
-        self.verticalLayout_11.setContentsMargins(0, 0, 0, 0)
         self.verticalLayout_11.setObjectName(u"verticalLayout_11")
+        self.verticalLayout_11.setContentsMargins(0, 0, 0, 0)
         self.displayDataPoints_frame = QFrame(self.displayData_frame)
         self.displayDataPoints_frame.setObjectName(u"displayDataPoints_frame")
         self.displayDataPoints_frame.setFrameShape(QFrame.StyledPanel)
         self.displayDataPoints_frame.setFrameShadow(QFrame.Raised)
         self.horizontalLayout_9 = QHBoxLayout(self.displayDataPoints_frame)
-        self.horizontalLayout_9.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_9.setObjectName(u"horizontalLayout_9")
+        self.horizontalLayout_9.setContentsMargins(0, 0, 0, 0)
         self.displayDataPoints_checkBox = QCheckBox(self.displayDataPoints_frame)
         self.displayDataPoints_checkBox.setObjectName(u"displayDataPoints_checkBox")
 
@@ -306,8 +306,8 @@ class Ui_ScaffoldCreatorWidget(object):
         self.displayDataMarkers_frame.setFrameShape(QFrame.StyledPanel)
         self.displayDataMarkers_frame.setFrameShadow(QFrame.Raised)
         self.horizontalLayout_10 = QHBoxLayout(self.displayDataMarkers_frame)
-        self.horizontalLayout_10.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_10.setObjectName(u"horizontalLayout_10")
+        self.horizontalLayout_10.setContentsMargins(0, 0, 0, 0)
         self.displayDataMarkerPoints_checkBox = QCheckBox(self.displayDataMarkers_frame)
         self.displayDataMarkerPoints_checkBox.setObjectName(u"displayDataMarkerPoints_checkBox")
 
@@ -333,9 +333,9 @@ class Ui_ScaffoldCreatorWidget(object):
         self.displayModelCoordinates_frame.setFrameShape(QFrame.StyledPanel)
         self.displayModelCoordinates_frame.setFrameShadow(QFrame.Raised)
         self.formLayout_3 = QFormLayout(self.displayModelCoordinates_frame)
-        self.formLayout_3.setContentsMargins(0, 0, 0, 0)
         self.formLayout_3.setObjectName(u"formLayout_3")
         self.formLayout_3.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
+        self.formLayout_3.setContentsMargins(0, 0, 0, 0)
         self.displayModelCoordinates_label = QLabel(self.displayModelCoordinates_frame)
         self.displayModelCoordinates_label.setObjectName(u"displayModelCoordinates_label")
 
@@ -354,8 +354,8 @@ class Ui_ScaffoldCreatorWidget(object):
         self.displayNodes_frame.setFrameShape(QFrame.StyledPanel)
         self.displayNodes_frame.setFrameShadow(QFrame.Raised)
         self.horizontalLayout_6 = QHBoxLayout(self.displayNodes_frame)
-        self.horizontalLayout_6.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_6.setObjectName(u"horizontalLayout_6")
+        self.horizontalLayout_6.setContentsMargins(0, 0, 0, 0)
         self.displayNodePoints_checkBox = QCheckBox(self.displayNodes_frame)
         self.displayNodePoints_checkBox.setObjectName(u"displayNodePoints_checkBox")
 
@@ -391,8 +391,8 @@ class Ui_ScaffoldCreatorWidget(object):
         self.displayNodeDerivativeLabels_frame.setFrameShape(QFrame.StyledPanel)
         self.displayNodeDerivativeLabels_frame.setFrameShadow(QFrame.Raised)
         self.horizontalLayout_7 = QHBoxLayout(self.displayNodeDerivativeLabels_frame)
-        self.horizontalLayout_7.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_7.setObjectName(u"horizontalLayout_7")
+        self.horizontalLayout_7.setContentsMargins(0, 0, 0, 0)
         self.displayNodeDerivativeLabels_horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Expanding, QSizePolicy.Minimum)
 
         self.horizontalLayout_7.addItem(self.displayNodeDerivativeLabels_horizontalSpacer)
@@ -454,8 +454,8 @@ class Ui_ScaffoldCreatorWidget(object):
         self.displayLines_frame.setFrameShape(QFrame.StyledPanel)
         self.displayLines_frame.setFrameShadow(QFrame.Raised)
         self.horizontalLayout_5 = QHBoxLayout(self.displayLines_frame)
-        self.horizontalLayout_5.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_5.setObjectName(u"horizontalLayout_5")
+        self.horizontalLayout_5.setContentsMargins(0, 0, 0, 0)
         self.displayLines_checkBox = QCheckBox(self.displayLines_frame)
         self.displayLines_checkBox.setObjectName(u"displayLines_checkBox")
 
@@ -485,8 +485,8 @@ class Ui_ScaffoldCreatorWidget(object):
         self.displaySurfaces_frame.setFrameShape(QFrame.StyledPanel)
         self.displaySurfaces_frame.setFrameShadow(QFrame.Raised)
         self.horizontalLayout_3 = QHBoxLayout(self.displaySurfaces_frame)
-        self.horizontalLayout_3.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_3.setObjectName(u"horizontalLayout_3")
+        self.horizontalLayout_3.setContentsMargins(0, 0, 0, 0)
         self.displaySurfaces_checkBox = QCheckBox(self.displaySurfaces_frame)
         self.displaySurfaces_checkBox.setObjectName(u"displaySurfaces_checkBox")
 
@@ -525,8 +525,8 @@ class Ui_ScaffoldCreatorWidget(object):
         self.displayElements_frame.setFrameShape(QFrame.StyledPanel)
         self.displayElements_frame.setFrameShadow(QFrame.Raised)
         self.horizontalLayout_4 = QHBoxLayout(self.displayElements_frame)
-        self.horizontalLayout_4.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_4.setObjectName(u"horizontalLayout_4")
+        self.horizontalLayout_4.setContentsMargins(0, 0, 0, 0)
         self.displayElementNumbers_checkBox = QCheckBox(self.displayElements_frame)
         self.displayElementNumbers_checkBox.setObjectName(u"displayElementNumbers_checkBox")
 
@@ -551,8 +551,8 @@ class Ui_ScaffoldCreatorWidget(object):
         self.displayMisc_frame.setFrameShape(QFrame.StyledPanel)
         self.displayMisc_frame.setFrameShadow(QFrame.Raised)
         self.horizontalLayout_8 = QHBoxLayout(self.displayMisc_frame)
-        self.horizontalLayout_8.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_8.setObjectName(u"horizontalLayout_8")
+        self.horizontalLayout_8.setContentsMargins(0, 0, 0, 0)
         self.displayAxes_checkBox = QCheckBox(self.displayMisc_frame)
         self.displayAxes_checkBox.setObjectName(u"displayAxes_checkBox")
 
@@ -580,8 +580,8 @@ class Ui_ScaffoldCreatorWidget(object):
         self.annoptationModify_frame.setFrameShape(QFrame.StyledPanel)
         self.annoptationModify_frame.setFrameShadow(QFrame.Raised)
         self.horizontalLayout_11 = QHBoxLayout(self.annoptationModify_frame)
-        self.horizontalLayout_11.setContentsMargins(0, 0, 0, 0)
         self.horizontalLayout_11.setObjectName(u"horizontalLayout_11")
+        self.horizontalLayout_11.setContentsMargins(0, 0, 0, 0)
         self.annotationGroupNew_pushButton = QPushButton(self.annoptationModify_frame)
         self.annotationGroupNew_pushButton.setObjectName(u"annotationGroupNew_pushButton")
 
@@ -597,6 +597,11 @@ class Ui_ScaffoldCreatorWidget(object):
 
         self.horizontalLayout_11.addWidget(self.annotationGroupRedefine_pushButton)
 
+        self.annotationGroupEdit_pushButton = QPushButton(self.annoptationModify_frame)
+        self.annotationGroupEdit_pushButton.setObjectName(u"annotationGroupEdit_pushButton")
+
+        self.horizontalLayout_11.addWidget(self.annotationGroupEdit_pushButton)
+
         self.annotationGroupDelete_pushButton = QPushButton(self.annoptationModify_frame)
         self.annotationGroupDelete_pushButton.setObjectName(u"annotationGroupDelete_pushButton")
 
@@ -610,8 +615,8 @@ class Ui_ScaffoldCreatorWidget(object):
         self.annotationGroup_frame.setFrameShape(QFrame.StyledPanel)
         self.annotationGroup_frame.setFrameShadow(QFrame.Raised)
         self.formLayout_2 = QFormLayout(self.annotationGroup_frame)
-        self.formLayout_2.setContentsMargins(0, 0, 0, 0)
         self.formLayout_2.setObjectName(u"formLayout_2")
+        self.formLayout_2.setContentsMargins(0, 0, 0, 0)
         self.annotationGroup_label = QLabel(self.annotationGroup_frame)
         self.annotationGroup_label.setObjectName(u"annotationGroup_label")
 
@@ -659,8 +664,8 @@ class Ui_ScaffoldCreatorWidget(object):
         self.marker_frame.setFrameShape(QFrame.StyledPanel)
         self.marker_frame.setFrameShadow(QFrame.Raised)
         self.formLayout_4 = QFormLayout(self.marker_frame)
-        self.formLayout_4.setContentsMargins(0, 0, 0, 0)
         self.formLayout_4.setObjectName(u"formLayout_4")
+        self.formLayout_4.setContentsMargins(0, 0, 0, 0)
         self.markerMaterialCoordinates_label = QLabel(self.marker_frame)
         self.markerMaterialCoordinates_label.setObjectName(u"markerMaterialCoordinates_label")
 
@@ -719,8 +724,8 @@ class Ui_ScaffoldCreatorWidget(object):
         self.bottom_frame.setFrameShape(QFrame.StyledPanel)
         self.bottom_frame.setFrameShadow(QFrame.Raised)
         self.horizontalLayout_2 = QHBoxLayout(self.bottom_frame)
-        self.horizontalLayout_2.setContentsMargins(3, 3, 3, 3)
         self.horizontalLayout_2.setObjectName(u"horizontalLayout_2")
+        self.horizontalLayout_2.setContentsMargins(3, 3, 3, 3)
         self.pushButtonDocumentation = QPushButton(self.bottom_frame)
         self.pushButtonDocumentation.setObjectName(u"pushButtonDocumentation")
 
@@ -814,6 +819,7 @@ class Ui_ScaffoldCreatorWidget(object):
         self.annotationGroupNew_pushButton.setText(QCoreApplication.translate("ScaffoldCreatorWidget", u"New", None))
         self.annotationGroupNewMarker_pushButton.setText(QCoreApplication.translate("ScaffoldCreatorWidget", u"New Marker", None))
         self.annotationGroupRedefine_pushButton.setText(QCoreApplication.translate("ScaffoldCreatorWidget", u"Redefine", None))
+        self.annotationGroupEdit_pushButton.setText(QCoreApplication.translate("ScaffoldCreatorWidget", u"Edit", None))
         self.annotationGroupDelete_pushButton.setText(QCoreApplication.translate("ScaffoldCreatorWidget", u"Delete", None))
         self.annotationGroup_label.setText(QCoreApplication.translate("ScaffoldCreatorWidget", u"Group:", None))
         self.annotationGroupOntId_label.setText(QCoreApplication.translate("ScaffoldCreatorWidget", u"ONT:ID:", None))


### PR DESCRIPTION
This PR adds an Edit button to the Annotation section of the GUI which opens the `cmlibs.widgets` `GroupManagerWidget` when clicked. This widget allows the user to redefine the currently selected annotation group based on nodes/elements contained in each of the other annotation groups.