### PR TITLE
Add getAdditionalConfigFiles to step interface

### DIFF
--- a/mapclientplugins/scaffoldcreator/model/mastermodel.py
+++ b/mapclientplugins/scaffoldcreator/model/mastermodel.py
@@ -118,7 +118,7 @@ class MasterModel(object):
     def loadSettings(self):
         try:
             settings = self._settings
-            with open(self._filenameStem + '-settings.json', 'r') as f:
+            with open(self.getSettingsFilename(), 'r') as f:
                 savedSettings = json.loads(f.read(), object_hook=Scaffolds_decodeJSON)
                 settings.update(savedSettings)
             # migrate from generator_settings in version 0.3.2
@@ -145,8 +145,11 @@ class MasterModel(object):
     def _saveSettings(self):
         self._creator_model.updateSettingsBeforeWrite()
         settings = self._getSettings()
-        with open(self._filenameStem + '-settings.json', 'w') as f:
+        with open(self.getSettingsFilename(), 'w') as f:
             f.write(json.dumps(settings, cls=Scaffolds_JSONEncoder, sort_keys=True, indent=4))
 
     def setSegmentationDataFile(self, data_filename):
         self._segmentation_data_model.setDataFilename(data_filename)
+
+    def getSettingsFilename(self):
+        return self._filenameStem + '-settings.json'

--- a/mapclientplugins/scaffoldcreator/step.py
+++ b/mapclientplugins/scaffoldcreator/step.py
@@ -51,15 +51,17 @@ class ScaffoldCreator(WorkflowStepMountPoint):
         Kick off the execution of the step, in this case an interactive dialog.
         User invokes the _doneExecution() method when finished, via pushbutton.
         """
-        QtWidgets.QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
-        self._model = MasterModel(self._location, self._config['identifier'])
-        if self._port1_inputZincDataFile:
-            self._model.setSegmentationDataFile(self._port1_inputZincDataFile)
-        self._view = ScaffoldCreatorWidget(self._model)
-        # self._view.setWindowFlags(QtCore.Qt.Widget)
-        self._view.registerDoneExecution(self._myDoneExecution)
-        self._setCurrentWidget(self._view)
-        QtWidgets.QApplication.restoreOverrideCursor()
+        QtWidgets.QApplication.setOverrideCursor(QtCore.Qt.CursorShape.WaitCursor)
+        try:
+            self._model = MasterModel(self._location, self._config['identifier'])
+            if self._port1_inputZincDataFile:
+                self._model.setSegmentationDataFile(self._port1_inputZincDataFile)
+            self._view = ScaffoldCreatorWidget(self._model)
+            # self._view.setWindowFlags(QtCore.Qt.Widget)
+            self._view.registerDoneExecution(self._myDoneExecution)
+            self._setCurrentWidget(self._view)
+        finally:
+            QtWidgets.QApplication.restoreOverrideCursor()
 
     def _myDoneExecution(self):
         self._portData0 = self._model.getOutputModelFilename()
@@ -145,3 +147,8 @@ class ScaffoldCreator(WorkflowStepMountPoint):
         d.identifierOccursCount = self._identifierOccursCount
         d.setConfig(self._config)
         self._configured = d.validate()
+
+    def getAdditionalConfigFiles(self):
+        if self._model is None:
+            self._model = MasterModel(self._location, self._config['identifier'])
+        return [self._model.getSettingsFilename()]


### PR DESCRIPTION
 This is used to report additional configuration files used by the step.  In this case the settings specified for creating the scaffold.